### PR TITLE
Change list for a3ad445df380b7a2dd8048bac7ee7f79bb61faa9 and follow-up patch

### DIFF
--- a/docs/Components/Button.md
+++ b/docs/Components/Button.md
@@ -12,6 +12,7 @@ A `Button` initiates an instantaneous action.
 
 | Property | Type                                                  | Description                                                                                  |
 | -------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `Disabled` | `#!luau boolean?`                                   | Prevents user interaction while preserving layout. Defaults to `false`.                      |
 | `State`  | `#!luau ("Primary" or "Secondary" or "Destructive")?` | Determines the weight of the button. Suggests to the user its impact on surrounding content. |
 | `Label`  | `#!luau string?`                                      | The text content of the button.                                                              |
 
@@ -35,6 +36,7 @@ A `Button` initiates an instantaneous action.
 
 ```luau
 type ButtonProperties = TextButton & {
+    Disabled: boolean?,
     State: ("Primary" | "Secondary" | "Destructive")?,
     Label: string?,
     Pushed: ((self: Button) -> unknown)?,
@@ -55,6 +57,7 @@ function(self, properties: ButtonProperties): Button
 local button = row:Right():Button({
     Label = "Button",
     State = "Primary",
+    Disabled = false,
     Pushed = function(self)
         print("Pushed")
     end,

--- a/docs/Components/KeybindField.md
+++ b/docs/Components/KeybindField.md
@@ -10,6 +10,7 @@ A `KeybindField` is a rectangular area in which people can enter and store `Enum
 
 | Property      | Type                   | Description                                                                   |
 | ------------- | ---------------------- | ----------------------------------------------------------------------------- |
+| `Disabled`    | `#!luau boolean?`      | Prevents shortcut capture and callback firing. Defaults to `false`.          |
 | `Placeholder` | `#!luau string?`       | The text placeholder to instruct users on how to interact with the component. |
 | `Value`       | `#!luau Enum.Keycode?` | The default shortcut the `KeybindField` is bound to.                          |
 
@@ -34,6 +35,7 @@ A `KeybindField` is a rectangular area in which people can enter and store `Enum
 
 ```luau
 type KeybindFieldProperties = Frame & {
+    Disabled: boolean?,
     Placeholder: string?,
     Value: Enum.KeyCode?,
     BindPressed: ((
@@ -58,6 +60,7 @@ function(self, properties: KeybindFieldProperties): KeybindField
 
 ```luau
 local keybindField = row:Right():KeybindField({
+    Disabled = false,
     ValueChanged = function(self, value: Enum.KeyCode)
         print("Value changed:", value)
     end,

--- a/docs/Components/PopUpButton.md
+++ b/docs/Components/PopUpButton.md
@@ -10,6 +10,7 @@ A `PopUpbutton` displays a menu of mutually exclusive/inclusive options.
 
 | Property   | Type                          | Description                                                                                                                            |
 | ---------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `Disabled` | `#!luau boolean?`             | Prevents user interaction while preserving layout. Defaults to `false`.                                                                |
 | `Options`  | `#!luau {[number]: string}?`  | You can use this table to pre-define options. Note that doing it this way will not give you access to the option instances themselves. |
 | `Expanded` | `#!luau boolean?`             | Defines the state of the dropdown disclosure.                                                                                          |
 | `Maximum`  | `#!luau number?`              | Maximum number of selectable options. Defaults to `1` (single-select).                                                                 |
@@ -40,6 +41,7 @@ A `PopUpbutton` displays a menu of mutually exclusive/inclusive options.
 
 ```luau
 type PopUpButtonProperties = Frame & {
+    Disabled: boolean?,
     Options: { [number]: string }?,
     Expanded: boolean?,
     Maximum: number?,
@@ -63,6 +65,7 @@ function(self, properties: PopUpButtonProperties): PopUpButton
 
 ```luau
 local popUpButton = row:Right():PopUpButton({
+    Disabled = false,
     Options = {
         "Item One",
         "Item Two",

--- a/docs/Components/PullDownButton.md
+++ b/docs/Components/PullDownButton.md
@@ -10,6 +10,7 @@ A `PullDownButton` displays a menu of mutually exclusive options.
 
 | Property   | Type                         | Description                                                                                                                            |
 | ---------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `Disabled` | `#!luau boolean?`            | Prevents user interaction while preserving layout. Defaults to `false`.                                                                |
 | `Options`  | `#!luau {[number]: string}?` | You can use this table to pre-define options. Note that doing it this way will not give you access to the option instances themselves. |
 | `Expanded` | `#!luau boolean?`            | Defines the state of the dropdown disclosure.                                                                                          |
 | `Label`    | `#!luau string?`             | Shows a label next to the disclosure button. Use it to describe the menu's content.                                                    |
@@ -32,7 +33,7 @@ A `PullDownButton` displays a menu of mutually exclusive options.
 
 | Event          | Signature                                                    | Description                                                                        |
 | -------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| `ValueChanged` | `#!luau ((self: PullDownButton, value: string) -> unknown)?` | A Callback function that is triggered when the `Value` property has been modified. |
+| `ValueChanged` | `#!luau ((self: PullDownButton, value: number) -> unknown)?` | A Callback function that is triggered when the `Value` property has been modified. |
 
 [View all inherited from `Frame`](https://create.roblox.com/docs/reference/engine/classes/Frame#summary-events)
 
@@ -40,6 +41,7 @@ A `PullDownButton` displays a menu of mutually exclusive options.
 
 ```luau
 type PullDownButtonProperties = Frame & {
+    Disabled: boolean?,
     Options: { [number]: string }?,
     Expanded: boolean?,
     Label: string?,
@@ -63,6 +65,7 @@ function(self, properties: PullDownButtonProperties): PullDownButton
 
 ```luau
 local pullDownButton = row:Right():PullDownButton({
+    Disabled = false,
     Label = "Action",
     Options = {
         "Action One",

--- a/docs/Components/RadioButtonGroup.md
+++ b/docs/Components/RadioButtonGroup.md
@@ -10,6 +10,7 @@ A `RadioButtonGroup` lets people choose an option from a set of mutually exclusi
 
 | Property  | Type                         | Description                                                                                                                            |
 | --------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `Disabled` | `#!luau boolean?`           | Prevents user interaction while preserving layout. Defaults to `false`.                                                                |
 | `Options` | `#!luau {[number]: string}?` | You can use this table to pre-define options. Note that doing it this way will not give you access to the option instances themselves. |
 | `Value`   | `#!luau number?`             | The numeric index of the option to be selected.                                                                                        |
 
@@ -37,6 +38,7 @@ A `RadioButtonGroup` lets people choose an option from a set of mutually exclusi
 
 ```luau
 type RadioButtonGroupProperties = Frame & {
+    Disabled: boolean?,
     Options: { [number]: string }?,
     Value: number?,
     ValueChanged: ((self: RadioButtonGroup, value: number) -> unknown)?,
@@ -57,6 +59,7 @@ function(self, properties: RadioButtonGroupProperties): RadioButtonGroup
 
 ```luau
 local radioButtonGroup = row:Right():RadioButtonGroup({
+    Disabled = false,
     Options = {
         "Option 1",
         "Option 2",

--- a/docs/Components/Slider.md
+++ b/docs/Components/Slider.md
@@ -10,6 +10,7 @@ A `Slider` is a horizontal track with a control, called a thumb, that people can
 
 | Property  | Type             | Description                             |
 | --------- | ---------------- | --------------------------------------- |
+| `Disabled` | `#!luau boolean?` | Prevents user interaction while preserving layout. Defaults to `false`. |
 | `Minimum` | `#!luau number?` | The minimum value the slider can go.    |
 | `Maximum` | `#!luau number?` | The maximum value the slider can reach. |
 | `Value`   | `#!luau number?` | The slider's current value.             |
@@ -34,6 +35,7 @@ A `Slider` is a horizontal track with a control, called a thumb, that people can
 
 ```luau
 type SliderProperties = ImageLabel & {
+    Disabled: boolean?,
     Minimum: number?,
     Maximum: number?,
     Value: number?,
@@ -53,6 +55,7 @@ function(self, properties: SliderProperties): Slider
 
 ```luau
 local slider = row:Right():Slider({
+    Disabled = false,
     Minimum = 0,
     Maximum = 10
     Value = 5,

--- a/docs/Components/Stepper.md
+++ b/docs/Components/Stepper.md
@@ -10,6 +10,7 @@ A `Stepper` is a two-segment control that people use to increase or decrease an 
 
 | Property  | Type              | Description                                                                    |
 | --------- | ----------------- | ------------------------------------------------------------------------------ |
+| `Disabled` | `#!luau boolean?` | Prevents user interaction while preserving layout. Defaults to `false`.        |
 | `Minimum` | `#!luau number?`  | The minimum value the stepper can drop.                                        |
 | `Maximum` | `#!luau number?`  | The maximum value the stepper can reach.                                       |
 | `Step`    | `#!luau number?`  | The increment to increase by on increase/decrease.                             |
@@ -41,6 +42,7 @@ A `Stepper` is a two-segment control that people use to increase or decrease an 
 
 ```luau
 type StepperProperties = ImageLabel & {
+    Disabled: boolean?,
     Minimum: number?,
     Maximum: number?,
     Step: number?,
@@ -65,6 +67,7 @@ function(self, properties: StepperProperties): Stepper
 
 ```luau
 local stepper = row:Right():Stepper({
+    Disabled = false,
     Minimum = 0,
     Maximum = 5,
     Step = 0.1,

--- a/docs/Components/TextField.md
+++ b/docs/Components/TextField.md
@@ -10,8 +10,9 @@ A `TextField` is a rectangular area in which people enter or edit small, specifi
 
 | Property      | Type                   | Description                                                                   |
 | ------------- | ---------------------- | ----------------------------------------------------------------------------- |
+| `Disabled`    | `#!luau boolean?`      | Prevents editing and value submission while preserving layout. Defaults to `false`. |
 | `Placeholder` | `#!luau string?`       | The text placeholder to instruct users on how to interact with the component. |
-| `Value`       | `#!luau Enum.Keycode?` | The text in the field.                                                        |
+| `Value`       | `#!luau string?`       | The text in the field.                                                        |
 
 [View all inherited from `BaseComponent`](./index.md/#properties)
 
@@ -34,6 +35,7 @@ A `TextField` is a rectangular area in which people enter or edit small, specifi
 
 ```luau
 type TextFieldProperties = Frame & {
+    Disabled: boolean?,
     Placeholder: string?,
     Value: string?,
     TextChanged: ((self: TextField, text: string) -> unknown)?,
@@ -54,6 +56,7 @@ function(self, properties: TextFieldProperties): TextField
 ```luau
 local textField = row:Right():TextField({
     Value = "Label",
+    Disabled = false,
     ValueChanged = function(self, value: string)
         print("Value changed:", value)
     end,

--- a/docs/Components/Toggle.md
+++ b/docs/Components/Toggle.md
@@ -10,6 +10,7 @@ A `Toggle` lets people choose between a pair of opposing states, like on and off
 
 | Property | Type              | Description                                        |
 | -------- | ----------------- | -------------------------------------------------- |
+| `Disabled` | `#!luau boolean?` | Prevents user interaction while preserving layout. Defaults to `false`. |
 | `Value`  | `#!luau boolean?` | The toggle's state. `false` for off, `true` for on |
 
 [View all inherited from `BaseComponent`](./index.md/#properties)
@@ -32,6 +33,7 @@ A `Toggle` lets people choose between a pair of opposing states, like on and off
 
 ```luau
 type ToggleProperties = Frame & {
+    Disabled: boolean?,
     Value: boolean?,
     ValueChanged: ((self: Toggle, value: boolean) -> unknown)?,
 }
@@ -50,6 +52,7 @@ function(self, properties: ToggleProperties): Toggle
 ```luau
 local toggle = row:Right():Toggle({
     Value = true,
+    Disabled = false,
     ValueChanged = function(self, value: boolean)
         print("Value changed:", value)
     end,

--- a/src/components/Button.luau
+++ b/src/components/Button.luau
@@ -5,6 +5,7 @@ return function(self, properties: types.ButtonProperties): types.Button
 	local creator = require("@modules/creator")
 	local binder = require("@modules/binder")
 	local services = require("@modules/services")
+	local interaction = require("@modules/interaction")
 
 	--// References
 	local create = creator.Create
@@ -20,6 +21,7 @@ return function(self, properties: types.ButtonProperties): types.Button
 	properties = properties or {}
 	properties.State = properties.State or "Primary"
 	properties.Label = properties.Label or "Label"
+	properties.Disabled = properties.Disabled == true
 
 	structures.Body = binder.Apply(
 		properties,
@@ -197,6 +199,11 @@ return function(self, properties: types.ButtonProperties): types.Button
 		Label = function(value: string)
 			structures.Label.Text = value
 		end,
+		Disabled = function(value: boolean)
+			interaction.setInteractable(structures.Body, not value)
+			structures.PressOverlay.BackgroundTransparency = 1
+			structures.Label.TextTransparency = value and 0.55 or labelContext.TextTransparency()
+		end,
 	}
 
 	object = binder.Wrap(properties, bindings, structures.Body)
@@ -205,8 +212,8 @@ return function(self, properties: types.ButtonProperties): types.Button
 	object.Theme = self.Theme
 	object.Structures = structures
 
-	structures.Body.MouseButton1Click:Connect(function()
-		if properties.Pushed then
+	interaction.connectActivate(structures.Body, function()
+		if not interaction.isDisabled(properties) and properties.Pushed then
 			task.spawn(properties.Pushed, object)
 		end
 	end)
@@ -222,6 +229,10 @@ return function(self, properties: types.ButtonProperties): types.Button
 	end
 
 	structures.Body.MouseButton1Down:Connect(function()
+		if interaction.isDisabled(properties) then
+			return
+		end
+
 		local tweenInfo = TweenInfo.new(0.08, Enum.EasingStyle.Cubic, Enum.EasingDirection.Out)
 
 		tweenService
@@ -235,6 +246,7 @@ return function(self, properties: types.ButtonProperties): types.Button
 	structures.Body.MouseLeave:Connect(animateRelease)
 
 	binder.Apply(properties, object)
+	bindings.Disabled(properties.Disabled)
 
 	return object
 end

--- a/src/components/KeybindField.luau
+++ b/src/components/KeybindField.luau
@@ -4,6 +4,7 @@ return function(self, properties: types.KeybindFieldProperties): types.KeybindFi
 	--// Imports
 	local binder = require("@modules/binder")
 	local services = require("@modules/services")
+	local interaction = require("@modules/interaction")
 
 	--// References
 	local userInputService = services.UserInputService
@@ -14,6 +15,8 @@ return function(self, properties: types.KeybindFieldProperties): types.KeybindFi
 	--// UI
 	properties = properties or {}
 	properties.Placeholder = properties.Placeholder or "Press a key"
+	properties.Disabled = properties.Disabled == true
+	local initialized = false
 
 	--// Initialize
 	structures.Field.TextXAlignment = Enum.TextXAlignment.Right
@@ -25,32 +28,41 @@ return function(self, properties: types.KeybindFieldProperties): types.KeybindFi
 	structures.Corner.CornerRadius = UDim.new(0, 6)
 
 	local object
-	object = binder.Wrap(properties, {
+	local bindings = {
 		Placeholder = function(value: string)
 			structures.Field.PlaceholderText = value
 		end,
 		Value = function(value: Enum.KeyCode)
-			structures.Field.Text = value.Name
+			structures.Field.Text = value and value.Name or ""
 
-			if properties.ValueChanged then
+			if properties.ValueChanged and initialized then
 				properties.Value = value
 				task.spawn(properties.ValueChanged, object, value)
 			end
 		end,
-	}, structures.Body)
+		Disabled = function(value: boolean)
+			interaction.setInteractable(structures.Field, not value)
+		end,
+	}
+
+	object = binder.Wrap(properties, bindings, structures.Body)
 
 	userInputService.InputBegan:Connect(function(input, gameProcessedEvent)
 		if input.UserInputType ~= Enum.UserInputType.Keyboard then
 			return
 		end
 
-		if input.KeyCode == properties.Value and properties.BindPressed then
+		if not interaction.isDisabled(properties) and input.KeyCode == properties.Value and properties.BindPressed then
 			properties.BindPressed(object, input.KeyCode, false, gameProcessedEvent)
 		end
 	end)
 
 	userInputService.InputEnded:Connect(function(input, gameProcessedEvent)
 		if input.UserInputType ~= Enum.UserInputType.Keyboard then
+			return
+		end
+
+		if interaction.isDisabled(properties) then
 			return
 		end
 
@@ -67,6 +79,8 @@ return function(self, properties: types.KeybindFieldProperties): types.KeybindFi
 	object.Structures = structures
 
 	binder.Apply(properties, object)
+	initialized = true
+	bindings.Disabled(properties.Disabled)
 
 	return object
 end

--- a/src/components/PopUpButton.luau
+++ b/src/components/PopUpButton.luau
@@ -5,16 +5,13 @@ return function(self, properties: types.PopUpButtonProperties): types.PopUpButto
 	local creator = require("@modules/creator")
 	local binder = require("@modules/binder")
 	local services = require("@modules/services")
+	local interaction = require("@modules/interaction")
+	local menu = require("@modules/menu")
 
 	--// References
 	local create = creator.Create
 
-	local userInputService = services.UserInputService
 	local tweenService = services.TweenService
-	local workspace = services.Workspace
-	local guiService = services.GuiService
-
-	local camera = workspace.CurrentCamera
 
 	--// Variables
 	local parent = self.__container or self.__instance or self
@@ -22,61 +19,36 @@ return function(self, properties: types.PopUpButtonProperties): types.PopUpButto
 	local structures = {
 		Options = {},
 	}
+	local connections = {}
 
 	--// Constants
 	local HORIZONTAL_OFFSET = -1
 	local VERTICAL_PADDING = 6
-	local EDGE_BUFFER = 6
-
 	local SIZE_CONSTRAINT_Y = 239
 
 	--// Functions
 	local function resize()
-		structures.Menu.AutomaticSize = Enum.AutomaticSize.XY
-
-		task.defer(function()
-			local menuHeight = structures.Menu.AbsoluteSize.Y
-
-			if menuHeight >= SIZE_CONSTRAINT_Y then
-				structures.Menu.AutomaticSize = Enum.AutomaticSize.X
-				structures.Menu.Size = UDim2.fromOffset(0, SIZE_CONSTRAINT_Y)
-			else
-				structures.Menu.Size = UDim2.fromOffset(0, menuHeight)
-				structures.Menu.AutomaticSize = Enum.AutomaticSize.X
-			end
-		end)
+		menu.resize(structures.Menu, SIZE_CONSTRAINT_Y)
 	end
 
 	local function anchor()
 		local body = structures.Body
-		local menu = structures.Menu
+		local menuFrame = structures.Menu
 
-		if not menu or not body then
+		if not menuFrame or not body then
 			return
 		end
 
-		local bodyPos = body.AbsolutePosition
-		local bodySize = body.AbsoluteSize
-		local menuSize = menu.AbsoluteSize
-		local viewportSize = camera.ViewportSize
-
-		local desiredX
+		local anchorElement = nil
 		if properties.Maximum and properties.Maximum > 1 then
-			local anchorElement = structures.PopUpIndicator or body
-			local anchorPos = anchorElement.AbsolutePosition
-			desiredX = anchorPos.X + HORIZONTAL_OFFSET
-		else
-			desiredX = bodyPos.X + HORIZONTAL_OFFSET
+			anchorElement = structures.PopUpIndicator or body
 		end
 
-		local desiredY = bodyPos.Y + bodySize.Y + VERTICAL_PADDING
-		local maxX = math.max(EDGE_BUFFER, viewportSize.X - EDGE_BUFFER - menuSize.X)
-		local maxY = math.max(EDGE_BUFFER, viewportSize.Y - EDGE_BUFFER - menuSize.Y)
-
-		desiredX = math.clamp(desiredX, EDGE_BUFFER, maxX)
-		desiredY = math.clamp(desiredY, EDGE_BUFFER, maxY)
-
-		menu.Position = UDim2.new(0, desiredX, 0, desiredY)
+		menu.anchor(body, menuFrame, {
+			AnchorElement = anchorElement,
+			HorizontalOffset = HORIZONTAL_OFFSET,
+			VerticalPadding = VERTICAL_PADDING,
+		})
 	end
 
 	local function option(object, name, index)
@@ -207,7 +179,7 @@ return function(self, properties: types.PopUpButtonProperties): types.PopUpButto
 		end)
 
 		option.MouseButton1Click:Connect(function()
-			if object then
+			if object and not interaction.isDisabled(properties) then
 				if object.Maximum and object.Maximum > 1 then
 					local current = object.Value or {}
 					if typeof(current) ~= "table" then
@@ -248,6 +220,8 @@ return function(self, properties: types.PopUpButtonProperties): types.PopUpButto
 	properties.Maximum = properties.Maximum or 1
 	properties.Expanded = properties.Expanded or false
 	properties.Options = properties.Options or {}
+	properties.Disabled = properties.Disabled == true
+	local initialized = false
 
 	structures.Body = binder.Apply(
 		properties,
@@ -258,7 +232,7 @@ return function(self, properties: types.PopUpButtonProperties): types.PopUpButto
 			BackgroundTransparency = 1,
 			BorderColor3 = Color3.fromRGB(0, 0, 0),
 			BorderSizePixel = 0,
-			Selectable = false,
+			Selectable = true,
 			Text = "",
 			Parent = parent,
 
@@ -416,6 +390,9 @@ return function(self, properties: types.PopUpButtonProperties): types.PopUpButto
 
 		Expanded = function(value: boolean)
 			local expand = value == true
+			if expand and interaction.isDisabled(properties) then
+				return
+			end
 
 			if expand then
 				structures.MenuContainer.Parent = structures.Body.__instance
@@ -505,10 +482,17 @@ return function(self, properties: types.PopUpButtonProperties): types.PopUpButto
 				end
 			end
 
-			if properties.ValueChanged then
+			if properties.ValueChanged and initialized then
 				properties.Value = value
 				task.spawn(properties.ValueChanged, object, value)
 			end
+		end,
+		Disabled = function(value: boolean)
+			interaction.setInteractable(structures.Body, not value)
+			if value then
+				object.Expanded = false
+			end
+			structures.CurrentTab.TextTransparency = value and 0.55 or self.Theme.Text.Primary[2].Value
 		end,
 	}
 
@@ -536,39 +520,29 @@ return function(self, properties: types.PopUpButtonProperties): types.PopUpButto
 	end
 
 	binder.Apply(properties, object)
+	bindings.Value(properties.Value)
+	initialized = true
+	bindings.Disabled(properties.Disabled)
 
 	structures.Body:GetPropertyChangedSignal("AbsolutePosition"):Connect(anchor)
 	structures.Body:GetPropertyChangedSignal("AbsoluteSize"):Connect(anchor)
 	structures.Menu:GetPropertyChangedSignal("AbsoluteSize"):Connect(anchor)
 
-	userInputService.InputBegan:Connect(function(input)
-		if
-			object.Expanded
-			and (
-				input.UserInputType == Enum.UserInputType.MouseButton1
-				or input.UserInputType == Enum.UserInputType.Touch
-			)
-		then
-			local mouse = userInputService:GetMouseLocation()
-			local inset = guiService:GetGuiInset()
-			local menuFrame = structures.Menu
-			local pos = menuFrame.AbsolutePosition
-			local size = menuFrame.AbsoluteSize
+	table.insert(connections, menu.connectOutsideClose(structures.Body, structures.Menu, function()
+		return object.Expanded
+	end, function()
+		object.Expanded = false
+	end))
+	table.insert(connections, menu.trackLifecycle(structures.Body, function()
+		interaction.disconnectAll(connections)
+		structures.MenuContainer.Parent = nil
+	end))
 
-			local adjustedMouseY = mouse.Y - inset.Y
-
-			if
-				mouse.X < pos.X
-				or mouse.X > pos.X + size.X
-				or adjustedMouseY < pos.Y
-				or adjustedMouseY > pos.Y + size.Y
-			then
-				object.Expanded = false
-			end
+	interaction.connectActivate(structures.Body, function()
+		if interaction.isDisabled(properties) then
+			return
 		end
-	end)
 
-	structures.Body.MouseButton1Click:Connect(function()
 		object.Expanded = not object.Expanded
 	end)
 

--- a/src/components/PullDownButton.luau
+++ b/src/components/PullDownButton.luau
@@ -5,16 +5,13 @@ return function(self, properties: types.PullDownButtonProperties): types.PullDow
 	local creator = require("@modules/creator")
 	local binder = require("@modules/binder")
 	local services = require("@modules/services")
+	local interaction = require("@modules/interaction")
+	local menu = require("@modules/menu")
 
 	--// References
 	local create = creator.Create
 
-	local userInputService = services.UserInputService
 	local tweenService = services.TweenService
-	local workspace = services.Workspace
-	local guiService = services.GuiService
-
-	local camera = workspace.CurrentCamera
 
 	--// Variables
 	local parent = self.__container or self.__instance or self
@@ -22,36 +19,24 @@ return function(self, properties: types.PullDownButtonProperties): types.PullDow
 	local structures = {
 		Options = {},
 	}
+	local connections = {}
 
 	--// Constants
 	local HORIZONTAL_OFFSET = -1
 	local VERTICAL_PADDING = 6
-	local EDGE_BUFFER = 6
-
 	--// Functions
 	local function anchor()
 		local body = structures.Body
-		local menu = structures.Menu
+		local menuFrame = structures.Menu
 
-		if not menu or not body then
+		if not menuFrame or not body then
 			return
 		end
 
-		local bodyPos = body.AbsolutePosition
-		local bodySize = body.AbsoluteSize
-		local menuSize = menu.AbsoluteSize
-		local viewportSize = camera.ViewportSize
-
-		local desiredX = bodyPos.X + HORIZONTAL_OFFSET
-		local desiredY = bodyPos.Y + (bodySize.Y * 3) + (VERTICAL_PADDING * 3) -- position below
-
-		local maxX = math.max(EDGE_BUFFER, viewportSize.X - EDGE_BUFFER - menuSize.X)
-		local maxY = math.max(EDGE_BUFFER, viewportSize.Y - EDGE_BUFFER - menuSize.Y)
-
-		desiredX = math.clamp(desiredX, EDGE_BUFFER, maxX)
-		desiredY = math.clamp(desiredY, EDGE_BUFFER, maxY)
-
-		menu.Position = UDim2.new(0, desiredX, 0, desiredY)
+		menu.anchor(body, menuFrame, {
+			HorizontalOffset = HORIZONTAL_OFFSET,
+			VerticalPadding = VERTICAL_PADDING,
+		})
 	end
 
 	local function option(object, name, index)
@@ -147,7 +132,7 @@ return function(self, properties: types.PullDownButtonProperties): types.PullDow
 		end)
 
 		option.MouseButton1Click:Connect(function()
-			if object then
+			if object and not interaction.isDisabled(properties) then
 				object.Expanded = false
 				object.Value = index
 			end
@@ -157,6 +142,8 @@ return function(self, properties: types.PullDownButtonProperties): types.PullDow
 	--// UI
 	properties = properties or {}
 	properties.Expanded = properties.Expanded or false
+	properties.Disabled = properties.Disabled == true
+	local initialized = false
 
 	structures.Body = binder.Apply(
 		properties,
@@ -167,7 +154,7 @@ return function(self, properties: types.PullDownButtonProperties): types.PullDow
 			BackgroundTransparency = 1,
 			BorderColor3 = Color3.fromRGB(0, 0, 0),
 			BorderSizePixel = 0,
-			Selectable = false,
+			Selectable = true,
 			Text = "",
 			Parent = parent,
 
@@ -324,6 +311,9 @@ return function(self, properties: types.PullDownButtonProperties): types.PullDow
 
 		Expanded = function(value: boolean)
 			local expand = value == true
+			if expand and interaction.isDisabled(properties) then
+				return
+			end
 
 			if expand then
 				structures.MenuContainer.Parent = structures.Body.__instance
@@ -351,10 +341,17 @@ return function(self, properties: types.PullDownButtonProperties): types.PullDow
 		end,
 
 		Value = function(value: number)
-			if properties.ValueChanged then
+			if properties.ValueChanged and initialized then
 				properties.Value = value
 				task.spawn(properties.ValueChanged, object, value)
 			end
+		end,
+		Disabled = function(value: boolean)
+			interaction.setInteractable(structures.Body, not value)
+			if value then
+				object.Expanded = false
+			end
+			structures.CurrentTab.TextTransparency = value and 0.55 or self.Theme.Text.Primary[2].Value
 		end,
 	}
 
@@ -381,39 +378,28 @@ return function(self, properties: types.PullDownButtonProperties): types.PullDow
 	end
 
 	binder.Apply(properties, object)
+	initialized = true
+	bindings.Disabled(properties.Disabled)
 
 	structures.Body:GetPropertyChangedSignal("AbsolutePosition"):Connect(anchor)
 	structures.Body:GetPropertyChangedSignal("AbsoluteSize"):Connect(anchor)
 	structures.Menu:GetPropertyChangedSignal("AbsoluteSize"):Connect(anchor)
 
-	userInputService.InputBegan:Connect(function(input)
-		if
-			object.Expanded
-			and (
-				input.UserInputType == Enum.UserInputType.MouseButton1
-				or input.UserInputType == Enum.UserInputType.Touch
-			)
-		then
-			local mouse = userInputService:GetMouseLocation()
-			local inset = guiService:GetGuiInset()
-			local menuFrame = structures.Menu
-			local pos = menuFrame.AbsolutePosition
-			local size = menuFrame.AbsoluteSize
+	table.insert(connections, menu.connectOutsideClose(structures.Body, structures.Menu, function()
+		return object.Expanded
+	end, function()
+		object.Expanded = false
+	end))
+	table.insert(connections, menu.trackLifecycle(structures.Body, function()
+		interaction.disconnectAll(connections)
+		structures.MenuContainer.Parent = nil
+	end))
 
-			local adjustedMouseY = mouse.Y - inset.Y
-
-			if
-				mouse.X < pos.X
-				or mouse.X > pos.X + size.X
-				or adjustedMouseY < pos.Y
-				or adjustedMouseY > pos.Y + size.Y
-			then
-				object.Expanded = false
-			end
+	interaction.connectActivate(structures.Body, function()
+		if interaction.isDisabled(properties) then
+			return
 		end
-	end)
 
-	structures.Body.MouseButton1Click:Connect(function()
 		object.Expanded = not object.Expanded
 	end)
 

--- a/src/components/RadioButtonGroup.luau
+++ b/src/components/RadioButtonGroup.luau
@@ -4,6 +4,7 @@ return function(self, properties: types.RadioButtonGroupProperties): types.Radio
 	--// Imports
 	local creator = require("@modules/creator")
 	local binder = require("@modules/binder")
+	local interaction = require("@modules/interaction")
 
 	--// References
 	local create = creator.Create
@@ -205,8 +206,8 @@ return function(self, properties: types.RadioButtonGroupProperties): types.Radio
 
 		local button = structures.RadioButtons[index]:FindFirstChild("Button") :: ImageButton
 		if button and button:IsA("ImageButton") then
-			button.MouseButton1Click:Connect(function()
-				if object then
+			interaction.connectActivate(button, function()
+				if object and not interaction.isDisabled(properties) then
 					object.Value = index
 				end
 			end)
@@ -216,6 +217,8 @@ return function(self, properties: types.RadioButtonGroupProperties): types.Radio
 	--// UI
 	properties = properties or {}
 	properties.Options = properties.Options or {}
+	properties.Disabled = properties.Disabled == true
+	local initialized = false
 
 	structures.Body = binder.Apply(
 		properties,
@@ -273,9 +276,17 @@ return function(self, properties: types.RadioButtonGroupProperties): types.Radio
 				end
 			end
 
-			if properties.ValueChanged then
+			if properties.ValueChanged and initialized then
 				properties.Value = value
 				task.spawn(properties.ValueChanged, object, value)
+			end
+		end,
+		Disabled = function(value: boolean)
+			for _, radioButton in ipairs(structures.RadioButtons) do
+				local button = radioButton and radioButton:FindFirstChild("Button")
+				if button then
+					interaction.setInteractable(button, not value)
+				end
 			end
 		end,
 	}
@@ -296,6 +307,11 @@ return function(self, properties: types.RadioButtonGroupProperties): types.Radio
 	end
 
 	binder.Apply(properties, object)
+	if properties.Value then
+		bindings.Value(properties.Value)
+	end
+	initialized = true
+	bindings.Disabled(properties.Disabled)
 
 	return object
 end

--- a/src/components/Slider.luau
+++ b/src/components/Slider.luau
@@ -4,6 +4,7 @@ return function(self, properties: types.SliderProperties): types.Slider
 	--// Imports
 	local creator = require("@modules/creator")
 	local binder = require("@modules/binder")
+	local interaction = require("@modules/interaction")
 
 	--// References
 	local create = creator.Create
@@ -19,6 +20,10 @@ return function(self, properties: types.SliderProperties): types.Slider
 	properties.Value = properties.Value or 0
 	properties.Maximum = properties.Maximum or 1
 	properties.Minimum = properties.Minimum or 0
+	properties.Disabled = properties.Disabled == true
+	properties.Minimum, properties.Maximum = interaction.validRange(properties.Minimum, properties.Maximum)
+	properties.Value = interaction.clampNumber(properties.Value, properties.Minimum, properties.Maximum)
+	local initialized = false
 
 	structures.Body = binder.Apply(
 		properties,
@@ -174,23 +179,38 @@ return function(self, properties: types.SliderProperties): types.Slider
 	local object
 	local bindings = {
 		Value = function(value: number)
+			local min, max = interaction.validRange(properties.Minimum, properties.Maximum)
+			value = interaction.clampNumber(value, min, max)
+
 			local sliderWidth = structures.Body.AbsoluteSize.X
 			local thumbWidth = structures.Thumb.AbsoluteSize.X
 			local thumbHalfWidth = thumbWidth / 2
 
-			local min = properties.Minimum
-			local max = properties.Maximum
-			local alpha = (value - min) / (max - min)
+			local alpha = max == min and 0 or (value - min) / (max - min)
 
 			local availableWidth = sliderWidth - thumbWidth
 			local fillWidth = thumbHalfWidth + (availableWidth * alpha)
 
 			structures.Fill.Size = UDim2.new(0, fillWidth, 1, 0)
 
-			if properties.ValueChanged then
+			if properties.ValueChanged and initialized then
 				properties.Value = value
 				task.spawn(properties.ValueChanged, object, value)
 			end
+		end,
+		Minimum = function(value: number)
+			properties.Minimum, properties.Maximum = interaction.validRange(value, properties.Maximum)
+			object.Value = properties.Value
+		end,
+		Maximum = function(value: number)
+			properties.Minimum, properties.Maximum = interaction.validRange(properties.Minimum, value)
+			object.Value = properties.Value
+		end,
+		Disabled = function(value: boolean)
+			interaction.setInteractable(structures.Body, not value)
+			interaction.setInteractable(structures.Thumb, not value)
+			interaction.setInteractable(structures.Dragger, not value)
+			structures.Thumb.BackgroundTransparency = 1
 		end,
 	}
 
@@ -201,10 +221,18 @@ return function(self, properties: types.SliderProperties): types.Slider
 	object.Structures = structures
 
 	structures.Dragger.DragStart:Connect(function()
+		if interaction.isDisabled(properties) then
+			return
+		end
+
 		dragStart = structures.Fill.AbsoluteSize.X
 	end)
 
 	structures.Dragger.DragContinue:Connect(function()
+		if interaction.isDisabled(properties) then
+			return
+		end
+
 		local sliderWidth = structures.Body.AbsoluteSize.X
 		local thumbWidth = structures.Thumb.AbsoluteSize.X
 		local thumbHalfWidth = thumbWidth / 2
@@ -221,7 +249,29 @@ return function(self, properties: types.SliderProperties): types.Slider
 		object.Value = object.Minimum + (object.Maximum - object.Minimum) * alpha
 	end)
 
+	structures.Body.InputBegan:Connect(function(input)
+		if interaction.isDisabled(properties) then
+			return
+		end
+
+		local step = (properties.Maximum - properties.Minimum) / 20
+
+		if input.KeyCode == Enum.KeyCode.Left or input.KeyCode == Enum.KeyCode.DPadLeft then
+			object.Value = object.Value - step
+		elseif input.KeyCode == Enum.KeyCode.Right or input.KeyCode == Enum.KeyCode.DPadRight then
+			object.Value = object.Value + step
+		elseif input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch then
+			local x = input.Position.X - structures.Body.AbsolutePosition.X
+			local width = math.max(structures.Body.AbsoluteSize.X, 1)
+			local alpha = math.clamp(x / width, 0, 1)
+
+			object.Value = properties.Minimum + (properties.Maximum - properties.Minimum) * alpha
+		end
+	end)
+
 	binder.Apply(properties, object)
+	initialized = true
+	bindings.Disabled(properties.Disabled)
 
 	return object
 end

--- a/src/components/Stepper.luau
+++ b/src/components/Stepper.luau
@@ -4,6 +4,7 @@ return function(self, properties: types.StepperProperties): types.Stepper
 	--// Imports
 	local creator = require("@modules/creator")
 	local binder = require("@modules/binder")
+	local interaction = require("@modules/interaction")
 
 	local textField = require("@structures/TextField")
 
@@ -19,6 +20,7 @@ return function(self, properties: types.StepperProperties): types.Stepper
 	local stepConnections = {}
 	local repeatDelay = 0.35
 	local repeatInterval = 0.083
+	local stepStop
 
 	--// Functions
 	local function getPrecision(step)
@@ -55,6 +57,11 @@ return function(self, properties: types.StepperProperties): types.Stepper
 	properties.Maximum = properties.Maximum or 1
 	properties.Minimum = properties.Minimum or 0
 	properties.Fielded = properties.Fielded or false
+	properties.Disabled = properties.Disabled == true
+	properties.Minimum, properties.Maximum = interaction.validRange(properties.Minimum, properties.Maximum)
+	properties.Step = math.abs(tonumber(properties.Step) or 0.1)
+	properties.Value = interaction.clampNumber(properties.Value, properties.Minimum, properties.Maximum)
+	local initialized = false
 
 	structures.Body = binder.Apply(
 		properties,
@@ -65,6 +72,7 @@ return function(self, properties: types.StepperProperties): types.Stepper
 			BorderColor3 = Color3.fromRGB(0, 0, 0),
 			BorderSizePixel = 0,
 			Image = "rbxassetid://85888499115674",
+			Selectable = true,
 			Size = UDim2.fromOffset(13, 20),
 			Parent = parent,
 
@@ -264,6 +272,8 @@ return function(self, properties: types.StepperProperties): types.Stepper
 			end
 		end,
 		Value = function(value: number)
+			value = interaction.clampNumber(value, properties.Minimum, properties.Maximum)
+
 			if value <= properties.Minimum then
 				structures.IMinus.ImageColor3 = self.Theme.Text.Tertiary[1].Value
 				structures.IMinus.ImageTransparency = self.Theme.Text.Tertiary[2].Value
@@ -271,7 +281,7 @@ return function(self, properties: types.StepperProperties): types.Stepper
 			else
 				structures.IMinus.ImageColor3 = self.Theme.Text.Primary[1].Value
 				structures.IMinus.ImageTransparency = self.Theme.Text.Primary[2].Value
-				structures.IMinus.Interactable = true
+				structures.IMinus.Interactable = not interaction.isDisabled(properties)
 			end
 
 			if value >= properties.Maximum then
@@ -281,16 +291,41 @@ return function(self, properties: types.StepperProperties): types.Stepper
 			else
 				structures.IPlus.ImageColor3 = self.Theme.Text.Primary[1].Value
 				structures.IPlus.ImageTransparency = self.Theme.Text.Primary[2].Value
-				structures.IPlus.Interactable = true
+				structures.IPlus.Interactable = not interaction.isDisabled(properties)
 			end
 
 			if structures.Field then
 				structures.Field.Field.Text = stepFormat(value, properties.Step)
 			end
 
-			if properties.ValueChanged then
+			if properties.ValueChanged and initialized then
 				properties.Value = value
 				task.spawn(properties.ValueChanged, object, value)
+			end
+		end,
+		Minimum = function(value: number)
+			properties.Minimum, properties.Maximum = interaction.validRange(value, properties.Maximum)
+			object.Value = properties.Value
+		end,
+		Maximum = function(value: number)
+			properties.Minimum, properties.Maximum = interaction.validRange(properties.Minimum, value)
+			object.Value = properties.Value
+		end,
+		Step = function(value: number)
+			properties.Step = math.abs(tonumber(value) or properties.Step or 0.1)
+			if properties.Step == 0 then
+				properties.Step = 0.1
+			end
+			object.Value = properties.Value
+		end,
+		Disabled = function(value: boolean)
+			interaction.setInteractable(structures.IPlus, not value and properties.Value < properties.Maximum)
+			interaction.setInteractable(structures.IMinus, not value and properties.Value > properties.Minimum)
+			structures.Field.Field.TextEditable = not value
+			interaction.setInteractable(structures.Field.Field, not value)
+			if value then
+				stepStop("Up")
+				stepStop("Down")
 			end
 		end,
 	}
@@ -301,8 +336,9 @@ return function(self, properties: types.StepperProperties): types.Stepper
 	object.Theme = self.Theme
 	object.Structures = structures
 	object.Increment = function()
-		assert(properties.Minimum)
-		assert(properties.Maximum)
+		if interaction.isDisabled(properties) then
+			return
+		end
 
 		local precision = math.max(getPrecision(object.Value), getPrecision(properties.Step))
 		local rawValue = object.Value + properties.Step
@@ -312,8 +348,9 @@ return function(self, properties: types.StepperProperties): types.Stepper
 	end
 
 	object.Decrement = function()
-		assert(properties.Minimum)
-		assert(properties.Maximum)
+		if interaction.isDisabled(properties) then
+			return
+		end
 
 		local precision = math.max(getPrecision(object.Value), getPrecision(properties.Step))
 		local rawValue = object.Value - properties.Step
@@ -323,6 +360,10 @@ return function(self, properties: types.StepperProperties): types.Stepper
 	end
 
 	local function stepStart(direction: string)
+		if interaction.isDisabled(properties) then
+			return
+		end
+
 		holding = true
 
 		local action = (direction == "Up") and object.Increment or object.Decrement
@@ -345,7 +386,7 @@ return function(self, properties: types.StepperProperties): types.Stepper
 		end)
 	end
 
-	local function stepStop(direction: string)
+	function stepStop(direction: string)
 		 holding = false
 		if stepConnections[direction] then
 			task.cancel(stepConnections[direction])
@@ -375,6 +416,18 @@ return function(self, properties: types.StepperProperties): types.Stepper
 		stepStop("Down")
 	end)
 
+	structures.Body.InputBegan:Connect(function(input)
+		if interaction.isDisabled(properties) then
+			return
+		end
+
+		if input.KeyCode == Enum.KeyCode.Up or input.KeyCode == Enum.KeyCode.DPadUp then
+			object.Increment()
+		elseif input.KeyCode == Enum.KeyCode.Down or input.KeyCode == Enum.KeyCode.DPadDown then
+			object.Decrement()
+		end
+	end)
+
 	structures.Body.AncestryChanged:Connect(function(_, parent)
 		if not parent then
 			stepStop("Up")
@@ -390,18 +443,11 @@ return function(self, properties: types.StepperProperties): types.Stepper
 
 	structures.Field.Field.FocusLost:Connect(function(fromEnter)
 		if fromEnter then
-			assert(properties.Minimum)
-			assert(properties.Maximum)
-
 			local text = structures.Field.Field.Text
 			local number = tonumber(text)
 
-			if number and properties.Fielded then
-				properties.Value = math.clamp(number, properties.Minimum, properties.Maximum)
-
-				if properties.Value then
-					bindings.Value(properties.Value)
-				end
+			if number and properties.Fielded and not interaction.isDisabled(properties) then
+				object.Value = interaction.clampNumber(number, properties.Minimum, properties.Maximum)
 			end
 		else
 			structures.Field.Field.Text = tostring(properties.Value)
@@ -409,6 +455,8 @@ return function(self, properties: types.StepperProperties): types.Stepper
 	end)
 
 	binder.Apply(properties, object)
+	initialized = true
+	bindings.Disabled(properties.Disabled)
 
 	return object
 end

--- a/src/components/TextField.luau
+++ b/src/components/TextField.luau
@@ -21,7 +21,7 @@ return function(self, properties: types.TextFieldProperties): types.TextField
 	structures.Body.Parent = self.__container or self.__instance or self
 
 	local object
-	object = binder.Wrap(properties, {
+	local bindings = {
 		Placeholder = function(value: string)
 			structures.Field.PlaceholderText = value
 		end,
@@ -46,7 +46,9 @@ return function(self, properties: types.TextFieldProperties): types.TextField
 				structures.Field.TextColor3 = self.Theme.Text.Primary[1].Value
 			end
 		end,
-	}, structures.Body)
+	}
+
+	object = binder.Wrap(properties, bindings, structures.Body)
 
 	structures.Field.Focused:Connect(function()
 		if interaction.isDisabled(properties) then

--- a/src/components/TextField.luau
+++ b/src/components/TextField.luau
@@ -3,6 +3,7 @@ local types = require("@types")
 return function(self, properties: types.TextFieldProperties): types.TextField
 	--// Imports
 	local binder = require("@modules/binder")
+	local interaction = require("@modules/interaction")
 
 	--// Variables
 	local structures = require("@structures/TextField")(self)
@@ -11,6 +12,8 @@ return function(self, properties: types.TextFieldProperties): types.TextField
 	properties = properties or {}
 	properties.Value = properties.Value ~= nil and properties.Value or ""
 	properties.Placeholder = properties.Placeholder or "Placeholder"
+	properties.Disabled = properties.Disabled == true
+	local initialized = false
 
 	--// Initialize
 	structures.Field.TextTruncate = Enum.TextTruncate.AtEnd
@@ -25,14 +28,32 @@ return function(self, properties: types.TextFieldProperties): types.TextField
 		Value = function(value: string)
 			structures.Field.Text = value
 
-			if properties.ValueChanged then
+			if properties.ValueChanged and initialized then
 				properties.Value = value
 				task.spawn(properties.ValueChanged, object, value)
+			end
+		end,
+		Disabled = function(value: boolean)
+			structures.Field.TextEditable = not value
+			interaction.setInteractable(structures.Field, not value)
+			if value then
+				structures.Field.TextTransparency = 0.55
+			elseif structures.Field.Text == "" then
+				structures.Field.TextTransparency = self.Theme.Text.Tertiary[2].Value
+				structures.Field.PlaceholderColor3 = self.Theme.Text.Tertiary[1].Value
+			else
+				structures.Field.TextTransparency = self.Theme.Text.Primary[2].Value
+				structures.Field.TextColor3 = self.Theme.Text.Primary[1].Value
 			end
 		end,
 	}, structures.Body)
 
 	structures.Field.Focused:Connect(function()
+		if interaction.isDisabled(properties) then
+			structures.Field:ReleaseFocus()
+			return
+		end
+
 		structures.Body.AutomaticSize = Enum.AutomaticSize.XY
 	end)
 
@@ -49,8 +70,14 @@ return function(self, properties: types.TextFieldProperties): types.TextField
 	object.Structures = structures
 
 	binder.Apply(properties, object)
+	initialized = true
+	bindings.Disabled(properties.Disabled)
 
 	structures.Field:GetPropertyChangedSignal("Text"):Connect(function()
+		if interaction.isDisabled(properties) then
+			return
+		end
+
 		if properties.TextChanged then
 			task.spawn(properties.TextChanged, object, structures.Field.Text or "")
 		end

--- a/src/components/Toggle.luau
+++ b/src/components/Toggle.luau
@@ -5,6 +5,7 @@ return function(self, properties: types.ToggleProperties): types.Row
 	local creator = require("@modules/creator")
 	local binder = require("@modules/binder")
 	local services = require("@modules/services")
+	local interaction = require("@modules/interaction")
 
 	--// References
 	local create = creator.Create
@@ -19,6 +20,8 @@ return function(self, properties: types.ToggleProperties): types.Row
 	--// UI
 	properties = properties or {}
 	properties.Value = properties.Value == true
+	properties.Disabled = properties.Disabled == true
+	local initialized = false
 
 	structures.Body = binder.Apply(
 		properties,
@@ -41,6 +44,7 @@ return function(self, properties: types.ToggleProperties): types.Row
 				Image = "rbxassetid://104426531889908",
 				ImageColor3 = Color3.fromRGB(0, 0, 0),
 				ImageTransparency = 0.91,
+				Selectable = true,
 				Size = UDim2.fromOffset(28, 16),
 
 				__dynamicKeys = {
@@ -127,10 +131,14 @@ return function(self, properties: types.ToggleProperties): types.Row
 				structures.Switch.ImageTransparency = switchGoal.ImageTransparency
 			end
 
-			if properties.ValueChanged and instant then
+			if properties.ValueChanged and instant and initialized then
 				properties.Value = value
 				task.spawn(properties.ValueChanged, object, value)
 			end
+		end,
+		Disabled = function(value: boolean)
+			interaction.setInteractable(structures.Switch, not value)
+			structures.Knob.ImageTransparency = value and 0.55 or theme.Knob[2].Value
 		end,
 	}
 
@@ -141,13 +149,19 @@ return function(self, properties: types.ToggleProperties): types.Row
 	object.Structures = structures
 
 	do -- Input handler
-		structures.Switch.MouseButton1Click:Connect(function()
+		interaction.connectActivate(structures.Switch, function()
+			if interaction.isDisabled(properties) then
+				return
+			end
+
 			object.Value = not object.Value
 		end)
 	end
 
 	bindings.Value(not not properties.Value, false)
 	binder.Apply(properties, object)
+	initialized = true
+	bindings.Disabled(properties.Disabled)
 
 	return object
 end

--- a/src/modules/interaction.luau
+++ b/src/modules/interaction.luau
@@ -1,4 +1,8 @@
+--// Variables
+
 local interaction = {}
+
+--// Public Methods
 
 function interaction.isDisabled(properties): boolean
 	return properties and properties.Disabled == true
@@ -69,5 +73,7 @@ function interaction.validRange(minimum: number?, maximum: number?): (number, nu
 
 	return min, max
 end
+
+--// Publish
 
 return interaction

--- a/src/modules/interaction.luau
+++ b/src/modules/interaction.luau
@@ -1,0 +1,73 @@
+local interaction = {}
+
+function interaction.isDisabled(properties): boolean
+	return properties and properties.Disabled == true
+end
+
+function interaction.setInteractable(instance: Instance?, enabled: boolean)
+	if not instance then
+		return
+	end
+
+	pcall(function()
+		instance.Active = enabled
+	end)
+	pcall(function()
+		instance.Selectable = enabled
+	end)
+	pcall(function()
+		instance.Interactable = enabled
+	end)
+end
+
+function interaction.connectActivate(button: GuiButton, callback: () -> ())
+	local connections = {}
+
+	local function activate()
+		callback()
+	end
+
+	if button.Activated then
+		table.insert(connections, button.Activated:Connect(activate))
+	else
+		table.insert(connections, button.MouseButton1Click:Connect(activate))
+	end
+
+	return connections
+end
+
+function interaction.disconnectAll(connections: { RBXScriptConnection? })
+	for _, connection in ipairs(connections) do
+		if connection then
+			connection:Disconnect()
+		end
+	end
+
+	table.clear(connections)
+end
+
+function interaction.clampNumber(value: number?, minimum: number?, maximum: number?): number
+	local resolved = tonumber(value) or minimum or 0
+	local min = minimum or resolved
+	local max = maximum or resolved
+
+	if max < min then
+		min, max = max, min
+	end
+
+	return math.clamp(resolved, min, max)
+end
+
+function interaction.validRange(minimum: number?, maximum: number?): (number, number)
+	local min = tonumber(minimum) or 0
+	local max = tonumber(maximum) or min
+
+	if max < min then
+		warn("Cascade: received Maximum below Minimum; swapping the range.")
+		min, max = max, min
+	end
+
+	return min, max
+end
+
+return interaction

--- a/src/modules/menu.luau
+++ b/src/modules/menu.luau
@@ -1,0 +1,105 @@
+local services = require("@modules/services")
+
+local menu = {}
+
+local userInputService = services.UserInputService
+local guiService = services.GuiService
+local workspace = services.Workspace
+
+local EDGE_BUFFER = 6
+local DEFAULT_VERTICAL_PADDING = 6
+
+function menu.anchor(body: GuiObject, popup: GuiObject, options)
+	options = options or {}
+
+	local camera = workspace.CurrentCamera
+	if not camera then
+		return
+	end
+
+	local bodyPos = body.AbsolutePosition
+	local bodySize = body.AbsoluteSize
+	local popupSize = popup.AbsoluteSize
+	local viewportSize = camera.ViewportSize
+
+	local desiredX = bodyPos.X + (options.HorizontalOffset or -1)
+	local desiredY = bodyPos.Y + bodySize.Y + (options.VerticalPadding or DEFAULT_VERTICAL_PADDING)
+
+	if options.AnchorElement then
+		desiredX = options.AnchorElement.AbsolutePosition.X + (options.HorizontalOffset or -1)
+	end
+
+	local maxX = math.max(EDGE_BUFFER, viewportSize.X - EDGE_BUFFER - popupSize.X)
+	local maxY = math.max(EDGE_BUFFER, viewportSize.Y - EDGE_BUFFER - popupSize.Y)
+
+	popup.Position = UDim2.new(
+		0,
+		math.clamp(desiredX, EDGE_BUFFER, maxX),
+		0,
+		math.clamp(desiredY, EDGE_BUFFER, maxY)
+	)
+end
+
+function menu.resize(menuFrame: ScrollingFrame, maxHeight: number?)
+	local limit = maxHeight or 239
+
+	menuFrame.AutomaticSize = Enum.AutomaticSize.XY
+
+	task.defer(function()
+		local menuHeight = menuFrame.AbsoluteSize.Y
+
+		if menuHeight >= limit then
+			menuFrame.AutomaticSize = Enum.AutomaticSize.X
+			menuFrame.Size = UDim2.fromOffset(0, limit)
+		else
+			menuFrame.Size = UDim2.fromOffset(0, menuHeight)
+			menuFrame.AutomaticSize = Enum.AutomaticSize.X
+		end
+	end)
+end
+
+function menu.connectOutsideClose(body: GuiObject, popup: GuiObject, isExpanded: () -> boolean, close: () -> ())
+	return userInputService.InputBegan:Connect(function(input)
+		if
+			not isExpanded()
+			or (
+				input.UserInputType ~= Enum.UserInputType.MouseButton1
+				and input.UserInputType ~= Enum.UserInputType.Touch
+			)
+		then
+			return
+		end
+
+		local mouse = userInputService:GetMouseLocation()
+		local inset = guiService:GetGuiInset()
+		local popupPos = popup.AbsolutePosition
+		local popupSize = popup.AbsoluteSize
+		local bodyPos = body.AbsolutePosition
+		local bodySize = body.AbsoluteSize
+		local adjustedMouseY = mouse.Y - inset.Y
+
+		local inPopup = mouse.X >= popupPos.X
+			and mouse.X <= popupPos.X + popupSize.X
+			and adjustedMouseY >= popupPos.Y
+			and adjustedMouseY <= popupPos.Y + popupSize.Y
+
+		local inBody = mouse.X >= bodyPos.X
+			and mouse.X <= bodyPos.X + bodySize.X
+			and adjustedMouseY >= bodyPos.Y
+			and adjustedMouseY <= bodyPos.Y + bodySize.Y
+
+		if not inPopup and not inBody then
+			close()
+		end
+	end)
+end
+
+function menu.trackLifecycle(root: Instance, cleanup: () -> ())
+	return root.AncestryChanged:Connect(function(_, parent)
+		if parent == nil then
+			cleanup()
+		end
+	end)
+end
+
+return menu

--- a/src/modules/menu.luau
+++ b/src/modules/menu.luau
@@ -1,4 +1,8 @@
+--// Imports
+
 local services = require("@modules/services")
+
+--// Variables
 
 local menu = {}
 
@@ -6,8 +10,12 @@ local userInputService = services.UserInputService
 local guiService = services.GuiService
 local workspace = services.Workspace
 
+--// Constants
+
 local EDGE_BUFFER = 6
 local DEFAULT_VERTICAL_PADDING = 6
+
+--// Public Methods
 
 function menu.anchor(body: GuiObject, popup: GuiObject, options)
 	options = options or {}
@@ -101,5 +109,7 @@ function menu.trackLifecycle(root: Instance, cleanup: () -> ())
 		end
 	end)
 end
+
+--// Publish
 
 return menu

--- a/src/types.luau
+++ b/src/types.luau
@@ -336,6 +336,7 @@ export type Symbol = BaseComponent & Components & SymbolProperties
 
 -- Toggle
 export type ToggleProperties = Frame & {
+	Disabled: boolean?,
 	Value: boolean?,
 	ValueChanged: ((self: Toggle, value: boolean) -> unknown)?,
 }
@@ -344,6 +345,7 @@ export type Toggle = BaseComponent & Components & ToggleProperties
 
 -- TextField
 export type TextFieldProperties = Frame & {
+	Disabled: boolean?,
 	Placeholder: string?,
 	Value: string?,
 	TextChanged: ((self: TextField, text: string) -> unknown)?,
@@ -354,6 +356,7 @@ export type TextField = BaseComponent & Components & TextFieldProperties
 
 -- KeybindField
 export type KeybindFieldProperties = Frame & {
+	Disabled: boolean?,
 	Placeholder: string?,
 	Value: Enum.KeyCode?,
 	BindPressed: ((
@@ -369,6 +372,7 @@ export type KeybindField = BaseComponent & Components & KeybindFieldProperties
 
 -- Slider
 export type SliderProperties = ImageLabel & {
+	Disabled: boolean?,
 	Minimum: number?,
 	Maximum: number?,
 	Value: number?,
@@ -379,6 +383,7 @@ export type Slider = BaseComponent & Components & SliderProperties
 
 -- Button
 export type ButtonProperties = TextButton & {
+	Disabled: boolean?,
 	State: ("Primary" | "Secondary" | "Destructive")?,
 	Label: string?,
 	Pushed: ((self: Button) -> unknown)?,
@@ -388,6 +393,7 @@ export type Button = BaseComponent & Components & ButtonProperties
 
 -- Stepper
 export type StepperProperties = ImageLabel & {
+	Disabled: boolean?,
 	Minimum: number?,
 	Maximum: number?,
 	Step: number?,
@@ -403,6 +409,7 @@ export type Stepper = BaseComponent & Components & StepperProperties & {
 
 -- RadioButtonGroup
 export type RadioButtonGroupProperties = Frame & {
+	Disabled: boolean?,
 	Options: { [number]: string }?,
 	Value: number?,
 	ValueChanged: ((self: RadioButtonGroup, value: number) -> unknown)?,
@@ -414,6 +421,7 @@ export type RadioButtonGroup = BaseComponent & Components & RadioButtonGroupProp
 
 -- PopUpButton
 export type PopUpButtonProperties = Frame & {
+	Disabled: boolean?,
 	Options: { [number]: string }?,
 	Expanded: boolean?,
 	Maximum: number?,
@@ -428,6 +436,7 @@ export type PopUpButton = BaseComponent & Components & PopUpButtonProperties & {
 
 -- PullDownButton
 export type PullDownButtonProperties = Frame & {
+	Disabled: boolean?,
 	Options: { [number]: string }?,
 	Expanded: boolean?,
 	Label: string?,

--- a/tests/test.client.luau
+++ b/tests/test.client.luau
@@ -174,6 +174,23 @@ do -- Main window
 					})
 				end
 
+				do -- Disabled Controls
+					local row = titledRow(form, "Disabled Controls", "Controls can be disabled without changing layout.")
+
+					row:Right():Button({
+						Label = "Disabled",
+						State = "Secondary",
+						Disabled = true,
+						Pushed = function(self)
+							print("This should not run")
+						end,
+					})
+					row:Right():Toggle({
+						Value = true,
+						Disabled = true,
+					})
+				end
+
 				do -- Slider
 					local row = titledRow(
 						form,
@@ -185,6 +202,8 @@ do -- Main window
 						Image = cascade.Symbols.sunMin,
 					})
 					row:Right():Slider({
+						Minimum = 0,
+						Maximum = 1,
 						Value = 0.5,
 						ValueChanged = function(self, value: number)
 							print("Value changed:", value)
@@ -204,6 +223,9 @@ do -- Main window
 					local label = row:Right():Label()
 
 					row:Right():Stepper({
+						Minimum = 0,
+						Maximum = 10,
+						Step = 1,
 						ValueChanged = function(self, value: number)
 							print("Value changed:", value)
 							label.Text = tostring(value)
@@ -216,6 +238,9 @@ do -- Main window
 
 					row:Right():Stepper({
 						Fielded = true,
+						Minimum = -1,
+						Maximum = 1,
+						Step = 0.25,
 						ValueChanged = function(self, value: number)
 							print("Value changed:", value)
 						end,


### PR DESCRIPTION
Commit: a3ad445 Improve component polish
- Updated docs for Button, KeybindField, PopUpButton, PullDownButton, RadioButtonGroup, Slider, Stepper, TextField, and Toggle.
- Added Disabled property documentation/examples across the affected component docs.
- Added disabled-state handling across Button, KeybindField, PopUpButton, PullDownButton, RadioButtonGroup, Slider, Stepper, TextField, and Toggle.
- Added interaction helpers in src/modules/interaction.luau for disabled checks, interactability toggling, activation wiring, connection cleanup, numeric clamping, and range validation.
- Added menu helpers in src/modules/menu.luau for popup anchoring, menu resizing, outside-click close handling, and lifecycle cleanup.
- Refined PopUpButton and PullDownButton menu behavior using shared menu helpers.
- Improved Slider value clamping/range handling and disabled-state input protection.
- Improved Stepper range/step handling, repeat stepping, fielded input behavior, and disabled-state input protection.
- Updated src/types.luau with new component property/type coverage.
- Expanded tests/demo coverage in tests/test.client.luau for disabled controls.

Follow-up changes:
- Fixed TextField runtime crash:
  - src/components/TextField.luau now stores the binding table in local bindings before passing it to binder.Wrap.
  - This fixes the nil access from calling bindings.Disabled(properties.Disabled).
- Applied requested code sectioning standard to new modules:
  - src/modules/interaction.luau now uses Variables, Public Methods, and Publish sections.
  - src/modules/menu.luau now uses Imports, Variables, Constants, Public Methods, and Publish sections.

Validation:
- Ran rojo build default.project.json successfully against a temporary output file.
