### PR TITLE
fix a handful of small bugs

### DIFF
--- a/src/components/Notification/ui.luau
+++ b/src/components/Notification/ui.luau
@@ -198,7 +198,7 @@ return function(self: any, properties: types.NotificationProperties, state: { Ag
 				BorderColor3 = Color3.fromRGB(0, 0, 0),
 				BorderSizePixel = 0,
 				Size = UDim2.fromScale(1, 0),
-				Visible = (properties.App ~= nil) or (properties.Icon ~= nil),
+				Visible = (properties.App ~= nil) or (properties.AppIcon ~= nil),
 
 				create("UIListLayout")({
 					Name = "UIListLayout",

--- a/src/components/PopUpButton.luau
+++ b/src/components/PopUpButton.luau
@@ -17,6 +17,15 @@ return function(self, properties: types.PopUpButtonProperties): types.PopUpButto
 	}
 
 	--// Functions
+	local MAX_DISPLAY_LENGTH = 30
+	local function truncate(text: string): string
+		if #text > MAX_DISPLAY_LENGTH then
+			return string.sub(text, 1, MAX_DISPLAY_LENGTH) .. "..."
+		end
+
+		return text
+	end
+
 	local function selectedMap(value)
 		local map = {}
 
@@ -196,7 +205,7 @@ return function(self, properties: types.PopUpButtonProperties): types.PopUpButto
 			if #labels == 0 then
 				structures.CurrentTab.Text = "None"
 			else
-				structures.CurrentTab.Text = table.concat(labels, ", ")
+				structures.CurrentTab.Text = truncate(table.concat(labels, ", "))
 			end
 
 			menu:SetSelectedMap(selectedMap(value))
@@ -206,7 +215,7 @@ return function(self, properties: types.PopUpButtonProperties): types.PopUpButto
 			if not optionLabel then
 				structures.CurrentTab.Text = "None"
 			else
-				structures.CurrentTab.Text = optionLabel.Text
+				structures.CurrentTab.Text = truncate(optionLabel.Text)
 			end
 
 			menu:SetSelectedMap(selectedMap(value))

--- a/src/components/PopUpButton.luau
+++ b/src/components/PopUpButton.luau
@@ -9,6 +9,9 @@ return function(self, properties: types.PopUpButtonProperties): types.PopUpButto
 	--// References
 	local create = creator.Create
 
+	--// Constants
+	local MAX_DISPLAY_LENGTH = 30
+
 	--// Variables
 	local parent = self.__container or self.__instance or self
 	local theme = self.Theme.Controls.MenuButton
@@ -16,8 +19,7 @@ return function(self, properties: types.PopUpButtonProperties): types.PopUpButto
 		Options = {},
 	}
 
-	--// Functions
-	local MAX_DISPLAY_LENGTH = 30
+	--// Private Methods
 	local function truncate(text: string): string
 		if #text > MAX_DISPLAY_LENGTH then
 			return string.sub(text, 1, MAX_DISPLAY_LENGTH) .. "..."

--- a/src/components/Section.luau
+++ b/src/components/Section.luau
@@ -191,10 +191,11 @@ return function(self, properties: types.SectionProperties): types.Section
 
 			sidebarGroup.AutomaticSize = Enum.AutomaticSize.None
 
-			for index, connection: RBXScriptConnection in pairs(connections) do
+			for _, connection: RBXScriptConnection in ipairs(connections) do
 				connection:Disconnect()
-				table.remove(connections, index)
 			end
+
+			table.clear(connections)
 
 			local updateSize = function(useTween: boolean)
 				local targetHeight = state and structures.Layout.AbsoluteContentSize.Y or 23

--- a/src/components/Slider.luau
+++ b/src/components/Slider.luau
@@ -180,7 +180,7 @@ return function(self, properties: types.SliderProperties): types.Slider
 
 			local min = properties.Minimum
 			local max = properties.Maximum
-			local alpha = (value - min) / (max - min)
+			local alpha = max ~= min and (value - min) / (max - min) or 0
 
 			local availableWidth = sliderWidth - thumbWidth
 			local fillWidth = thumbHalfWidth + (availableWidth * alpha)

--- a/src/components/Symbol.luau
+++ b/src/components/Symbol.luau
@@ -45,7 +45,7 @@ return function(self, properties: types.SymbolProperties): types.Symbol
 	local object = binder.Wrap(properties, {
 		Style = function(value: "Primary" | "Secondary")
 			if value == "Primary" then
-				structures.Body.ImageColor3 = self.Theme.Text.Primary[1].Value.Value
+				structures.Body.ImageColor3 = self.Theme.Text.Primary[1].Value
 				structures.Body.ImageTransparency = self.Theme.Text.Primary[2].Value
 			else
 				structures.Body.ImageColor3 = self.Theme.Text.Secondary[1].Value

--- a/src/structures/Titlebar.luau
+++ b/src/structures/Titlebar.luau
@@ -364,7 +364,7 @@ return function(self)
 
 	--// Initialize
 	structures.CornerClipLeft = structures.Body:FindFirstChild("CornerClipLeft") :: Frame
-	structures.CornerClipRight = structures.Body:FindFirstChild("ConerClipRight") :: Frame
+	structures.CornerClipRight = structures.Body:FindFirstChild("CornerClipRight") :: Frame
 	structures.Content = structures.Body:FindFirstChild("Content") :: Frame
 	structures.Leading = structures.Content:FindFirstChild("Leading") :: Frame
 	structures.Trailing = structures.Content:FindFirstChild("Trailing") :: Frame

--- a/tests/test.client.luau
+++ b/tests/test.client.luau
@@ -295,12 +295,11 @@ do -- Main window
 				do -- Multi pop-up button with many options
 					local row = titledRow(
 						form,
-						"Pop Up Button (Maximum=3) (many options)",
+						"Pop Up Button i = 20 (Maximum = i) (options = i)",
 						"Multi Pop Up Button with many options"
 					)
 
 					local multi = row:Right():PopUpButton({
-						Maximum = 3,
 						ValueChanged = function(self, value)
 							print("Selections:")
 							for _, idx in ipairs(value or {}) do
@@ -310,6 +309,7 @@ do -- Main window
 					})
 
 					for i = 1, 20 do
+						multi.Maximum = i
 						multi:Option(`Option {tostring(i)}`)
 					end
 				end


### PR DESCRIPTION
hey, ran into a few small bugs while using the library and figured i'd send the fixes upstream. all of these are tiny and self-contained, no behavior changes beyond the bug itself.

### what's in here

- **PopUpButton** – the selection label has `TextTruncate.AtEnd` but the label is `AutomaticSize.XY`, so truncate never actually kicks in. a long option name or a multi-select with a bunch of options just stretches the button out and wrecks the layout. added a small `truncate()` helper and capped the displayed text at 30 chars + `...` (both the multi and single select paths).
- **Titlebar** – `structures.CornerClipRight` was looking up `"ConerClipRight"` (missing an `r`) while the frame is created as `"CornerClipRight"`, so it was always nil.
- **Notification** – the topbar's initial `Visible` was checking `properties.Icon`, but `Icon` is the content title icon, not the topbar one. the `App`/`AppIcon` bindings in `init.luau` both gate the topbar on `AppIcon`, so the static value should too. without this, setting only `Icon` shows an empty topbar.
- **Symbol** – the `Style = "Primary"` branch had one extra `.Value` (`Primary[1].Value` is already the `Color3`, see the Secondary branch / `__dynamicKeys` / `__contextKeys` right next to it). indexing a `Color3` with `.Value` errors, so switching `Style` to `"Primary"` at runtime silently did nothing (only masked because the static dynamic key already points at Primary).
- **Section** – the expand cleanup loop did `table.remove(connections, index)` while iterating with `pairs(connections)`. removing during iteration skips elements, so roughly half the connections never got disconnected and leaked on every expand/collapse toggle. swapped it for disconnect-all then `table.clear`.
- **Slider** – `(value - min) / (max - min)` divides by zero when `Minimum == Maximum`, which makes the fill size NaN. guarded it.

### notes

- nothing touches `CHANGELOG.md` on purpose – figured you'd rather manage release notes yourself, happy to add an entry if you want.
- separately filed an issue about a leaked-connection pattern i kept seeing (UserInputService connections that never get disconnected) since that one needs a design call rather than a quick patch.

let me know if you want anything split out or tweaked 👍
